### PR TITLE
Fix library when using latest seneca version

### DIFF
--- a/index.js
+++ b/index.js
@@ -245,8 +245,8 @@ module.exports = function (options) {
                         return !this.has(args);
                     },
 
-                    send: function (args, done) {
-                        var outmsg = tu.prepare_request(this, args, done);
+                    send: function (args, done, meta) {
+                        var outmsg = tu.prepare_request(this, args, done, meta);
                         act_topic.publish({
                             data: tu.stringifyJSON(seneca, 'client-' + type, outmsg)
                         }, function (err) {


### PR DESCRIPTION
I could not use this library because I encountered the same bug as here:
https://github.com/senecajs/seneca-redis-pubsub-transport/issues/42

So I fixed it using the same method.